### PR TITLE
add <svelte:fragment> element

### DIFF
--- a/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteTagProvider.kt
+++ b/src/main/java/dev/blachut/svelte/lang/codeInsight/SvelteTagProvider.kt
@@ -23,7 +23,7 @@ const val mediumPriority = 50.0
 const val svelteNamespace = "svelte"
 const val sveltePrefix = "$svelteNamespace:"
 
-val svelteTagNames = arrayOf("self", "component", "window", "body", "head", "options")
+val svelteTagNames = arrayOf("self", "component", "window", "body", "head", "options", "fragment")
 
 // TODO Merge with svelteBareTagLookupElements
 // TODO Use XmlTagInsertHandler


### PR DESCRIPTION
Since svelte 3.35.0, the `<svelte:fragment name="slot-name"/>` is provided to allow slot to be provided without a container (https://github.com/sveltejs/svelte/blob/master/CHANGELOG.md#3350)